### PR TITLE
Init.d Script to Spawn Runner(s) at bootime

### DIFF
--- a/lib/support/init.d/gitlab_ci_runner
+++ b/lib/support/init.d/gitlab_ci_runner
@@ -1,6 +1,9 @@
 #! /bin/bash
 
 ### BEGIN INIT INFO
+# Provides           gitlab-ci-runner
+# Required-Start:    $local_fs $remote_fs $network $syslog
+# Required-Stop:     $local_fs $remote_fs $network $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: GitLab CI Runner init.d script


### PR DESCRIPTION
Here is /etc/init.d/gitlab-ci-runner startup script I wanted to run by you guys. It supports spanning multiple runners at boot time via `RUNNERS_NUM` var (not sure whether this is needed though or not). The default value is set to 1, so it will start only one runner instance at boot time. It also supports killing ghost runner processes that don't have corresponding PIDs recorded in the `runners.pid` file. May be useful for those scenarios when PID file is missing or some runners have been spawned manually.

Typical install:

```
sudo cp lib/support/init.d/gitlab-ci-runner /etc/init.d/gitlab-ci-runner
sudo chmod +x /etc/init.d/gitlab-ci-runner
sudo update-rc.d gitlab-ci-runner defaults 21 
sudo /etc/init.d/gitlab-ci-runner start
```

Feel free to comment.
