### PR TITLE
Disabled nohup.out being generated in the project root

### DIFF
--- a/lib/support/init.d/gitlab_ci_runner
+++ b/lib/support/init.d/gitlab_ci_runner
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 ### BEGIN INIT INFO
-# Provides           gitlab-ci-runner
+# Provides:          gitlab-ci-runner
 # Required-Start:    $local_fs $remote_fs $network $syslog
 # Required-Stop:     $local_fs $remote_fs $network $syslog
 # Default-Start:     2 3 4 5


### PR DESCRIPTION
Fixed issue with nohup.out being generated due to superfluous space before /dev/null redirect.
