### PR TITLE
Fix init.d script. Missing colon cause error during service registration

### DIFF
--- a/lib/support/init.d/gitlab_ci_runner
+++ b/lib/support/init.d/gitlab_ci_runner
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 ### BEGIN INIT INFO
-# Provides           gitlab-ci-runner
+# Provides:          gitlab-ci-runner
 # Required-Start:    $local_fs $remote_fs $network $syslog
 # Required-Stop:     $local_fs $remote_fs $network $syslog
 # Default-Start:     2 3 4 5


### PR DESCRIPTION
Missing colon cause error during registration:

```
sudo update-rc.d gitlab_ci_runner defaults 21
```
