### PR TITLE
Make branch name visible for build scripts through $CI_BUILD_REF_NAME

### DIFF
--- a/lib/build.rb
+++ b/lib/build.rb
@@ -14,6 +14,7 @@ module GitlabCi
     def initialize(data)
       @commands = data[:commands].to_a
       @ref = data[:ref]
+      @ref_name = data[:ref_name]
       @id = data[:id]
       @project_id = data[:project_id]
       @repo_url = data[:repo_url]
@@ -95,6 +96,7 @@ module GitlabCi
       @process.environment['CI_SERVER_REVISION'] = nil# GitlabCi::Revision
 
       @process.environment['CI_BUILD_REF'] = @ref
+      @process.environment['CI_BUILD_REF_NAME'] = @ref_name
 
       @process.start
 

--- a/lib/network.rb
+++ b/lib/network.rb
@@ -34,6 +34,7 @@ module GitlabCi
           commands: response['commands'].lines,
           repo_url: response['repo_url'],
           ref: response['sha'],
+          ref_name: response['ref'],
         }
       elsif response.code == 403
         puts 'forbidden'


### PR DESCRIPTION
According to https://github.com/gitlabhq/gitlab-ci-runner/issues/10

also mentioned https://github.com/gitlabhq/gitlab-ci/issues/74
