### PR TITLE
Added build id as environment variable

### DIFF
--- a/lib/build.rb
+++ b/lib/build.rb
@@ -97,6 +97,7 @@ module GitlabCi
 
       @process.environment['CI_BUILD_REF'] = @ref
       @process.environment['CI_BUILD_REF_NAME'] = @ref_name
+      @process.environment['CI_BUILD_ID'] = @id
 
       @process.start
 


### PR DESCRIPTION
The build ID can be useful in versioning builds.
