### PR TITLE
Make runner more shell-like

### DIFF
--- a/lib/build.rb
+++ b/lib/build.rb
@@ -75,12 +75,29 @@ module GitlabCi
       status = 0
 
       @output ||= ""
+      @tmp_file = Tempfile.new("child-output", binmode: true)
+      @tmp_file_path = @tmp_file.path
+
+      # don't do anything if the cmd is empty
+      if cmd.empty?
+        return true
+      end
+
       @output << "\n"
+      @output << "\033[0;30;1m"
+      @output << @ref
+      @output << "@"
+      @output << @ref_name
+      @output << ":~#\033[0m "
       @output << cmd
       @output << "\n"
 
+      # ignore comments
+      if cmd.start_with?( "#" )
+        return true
+      end
+
       @process = ChildProcess.build(cmd)
-      @tmp_file = Tempfile.new("child-output", binmode: true)
       @process.io.stdout = @tmp_file
       @process.io.stderr = @tmp_file
       @process.cwd = project_dir
@@ -100,8 +117,6 @@ module GitlabCi
       @process.environment['CI_BUILD_ID'] = @id
 
       @process.start
-
-      @tmp_file_path = @tmp_file.path
 
       begin
         @process.poll_for_exit(TIMEOUT)


### PR DESCRIPTION
What this means is:
```
Scripts field can contain empty lines now
Scripts field can contain shell-like comment lines (allows to temporally disable a command, or just comment onto something)
Output looks more shell like (commands being executed and output resulting from these is now easier to distinguish)
```
The diff also contains some comments that explain where each feature is located (except for the Output one but that should be obvious)

I had to move up the tmp_file variables due to the early returns

Note: the command being executed is prefixed by a bash like user host sheme, however using that makes not much sense so I used the ref-id@ref-name, this "command line" is also highlighted trough applying the color grey onto it (I noticed that a ANSI color parser is included and made use of it :P) here's an image to visualize what I just said: http://puu.sh/4vJ65.png

I hope that it's easy enough to be merged in without much complaining as it only adds harmless things :D (which can be quite useful tough)