### PR TITLE
Clean up ignored files when fetching

### DIFF
--- a/lib/build.rb
+++ b/lib/build.rb
@@ -148,7 +148,7 @@ module GitlabCi
       cmd = []
       cmd << "cd #{project_dir}"
       cmd << "git reset --hard"
-      cmd << "git clean -f"
+      cmd << "git clean -fx"
       cmd << "git fetch"
       cmd.join(" && ")
     end


### PR DESCRIPTION
I have 'composer.lock' in my .gitignore file, and the current command leaves it there between builds.

This means that the build environment is not clean between builds, causing issues.
