### PR TITLE
Added http proxy support

### DIFF
--- a/lib/network.rb
+++ b/lib/network.rb
@@ -7,6 +7,11 @@ require 'json'
 module GitlabCi
   class Network
     include HTTParty
+    # Use http proxy if specified in the shell
+    if ENV["HTTP_PROXY"]
+      (protocol,host,port) = ENV["HTTP_PROXY"].split(/:\/\/|:/)
+      http_proxy host, port
+    end
 
     # check for available build from coordinator
     # and pick a pending one


### PR DESCRIPTION
If a HTTP_PROXY environment variable exists, the runner should use it automatically.

This will enable the runner to run behind corporate firewalls where all web traffic must go trough a http proxy.
