### PR TITLE
removed pry dependency

### DIFF
--- a/lib/network.rb
+++ b/lib/network.rb
@@ -1,7 +1,6 @@
 require_relative 'config'
 
 require 'httparty'
-require 'pry'
 require 'json'
 
 module GitlabCi


### PR DESCRIPTION
The installation script fails moaning pry isn't installed, I removed the dependency from network.rb and the script now runs successfully.

The exception:

```
/gitlab-ci-runner/lib/network.rb:4:in `require': cannot load such file -- pry (LoadError)
```
