### PR TITLE
Make sure runners_registered is valid when no pid file exists

### DIFF
--- a/lib/support/init.d/gitlab_ci_runner
+++ b/lib/support/init.d/gitlab_ci_runner
@@ -25,6 +25,7 @@ INIT_LOG="/var/log/gitlab_ci_runner.log"
 
 check_pid() {
   # Number of registered runners in PID file
+  RUNNERS_REGISTERED=0
   [ -f $RUNNERS_PID ] && RUNNERS_REGISTERED=`cat $RUNNERS_PID | wc -l`
 
   # Number of active runner processes


### PR DESCRIPTION
Fixes `service gitlab-ci-runner restart` falure due to missing reset of `RUNNERS_REGISTERED` in case no PID file exists.

buggy

    root@xyz:~# service gitlab-ci-runner restart
    Number of registered runners in PID file=1
    Number of running runners=1
    Trying to stop registered runners...OK
    No ghost runners have been found.This is good.
    Number of registered runners in PID file=1
    Number of running runners=1
    Error! GitLab CI runner(s) (gitlab-ci-runner) appear to be running already! Try stopping them first. Exiting.

    root@xyz:~# service gitlab-ci-runner restart
    Number of registered runners in PID file=0
    Number of running runners=0
    No runners have been found. Exiting.
    Trying to stop registered runners...FAILED!
    Couldn't stop registered runners as there is no record of such in /home/gitlab_ci_runner/gitlab-runners/gitlab-ci-runner/tmp/pids/runners.pid file.
    No ghost runners have been found.This is good.
    Number of registered runners in PID file=0
    Number of running runners=0
    Starting runner #1
    SUCCESS: Started 1 GitLab CI runner(s).

fixed

    root@xyz:/etc/init.d# service gitlab-ci-runner restart
    Number of registered runners in PID file=1
    Number of running runners=1
    Trying to stop registered runners...OK
    No ghost runners have been found.This is good.
    Number of registered runners in PID file=0
    Number of running runners=0
    Starting runner #1
    SUCCESS: Started 1 GitLab CI runner(s).
