### PR TITLE
Greatly enhanced handling of child process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ group :development do
   gem 'guard-rspec'
   gem 'vcr'
   gem 'pry'
+  gem 'awesome_print'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     addressable (2.3.4)
+    awesome_print (1.2.0)
     charlock_holmes (0.6.9.4)
     childprocess (0.3.6)
       ffi (~> 1.0, >= 1.0.6)
@@ -73,6 +74,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  awesome_print
   charlock_holmes (= 0.6.9.4)
   childprocess (= 0.3.6)
   coveralls

--- a/lib/build.rb
+++ b/lib/build.rb
@@ -5,28 +5,30 @@ require 'childprocess'
 require 'tempfile'
 require 'fileutils'
 require 'bundler'
+require 'shellwords'
 
 module GitlabCi
   class Build
     TIMEOUT = 7200
 
-    attr_accessor :id, :commands, :ref, :tmp_file_path, :output, :state, :before_sha
+    attr_accessor :id, :commands, :ref, :tmp_file_path, :output, :before_sha
 
     def initialize(data)
+      @output = ""
       @commands = data[:commands].to_a
       @ref = data[:ref]
       @ref_name = data[:ref_name]
       @id = data[:id]
       @project_id = data[:project_id]
       @repo_url = data[:repo_url]
-      @state = :waiting
       @before_sha = data[:before_sha]
       @timeout = data[:timeout] || TIMEOUT
       @allow_git_fetch = data[:allow_git_fetch]
     end
 
     def run
-      @state = :running
+      @run_file = Tempfile.new("executor")
+      @run_file.chmod(0755)
 
       @commands.unshift(checkout_cmd)
 
@@ -38,28 +40,45 @@ module GitlabCi
         @commands.unshift(clone_cmd)
       end
 
-      @commands.each do |line|
-        status = Bundler.with_clean_env { command line }
-        @state = :failed and return unless status
-      end
+      @run_file.puts %|#!/bin/bash|
+      @run_file.puts %|set -e|
+      @run_file.puts %|trap 'kill -s INT 0' EXIT|
 
-      @state = :success
+      @commands.each do |command|
+        @run_file.puts %|echo #{command.shellescape}|
+        @run_file.puts(command)
+      end
+      @run_file.close
+
+      Bundler.with_clean_env { execute("setsid #{@run_file.path}") }
+    end
+
+    def state
+      return :success if success?
+      return :failed if failed?
+      :running
     end
 
     def completed?
-      success? || failed?
+      @process.exited?
     end
 
     def success?
-      state == :success
+      return nil unless completed?
+      @process.exit_code == 0
     end
 
     def failed?
-      state == :failed
+      return nil unless completed?
+      @process.exit_code != 0
     end
 
     def running?
-      state == :running
+      @process.alive?
+    end
+
+    def abort
+      @process.stop
     end
 
     def trace
@@ -73,16 +92,18 @@ module GitlabCi
       tmp_file_output ||= ''
     end
 
+    def cleanup
+      @tmp_file.rewind
+      @output << GitlabCi::Encode.encode!(@tmp_file.read)
+      @tmp_file.close
+      @tmp_file.unlink
+      @run_file.unlink
+    end
+
     private
 
-    def command(cmd)
+    def execute(cmd)
       cmd = cmd.strip
-      status = 0
-
-      @output ||= ""
-      @output << "\n"
-      @output << cmd
-      @output << "\n"
 
       @process = ChildProcess.build(cmd)
       @tmp_file = Tempfile.new("child-output", binmode: true)
@@ -106,27 +127,8 @@ module GitlabCi
       @process.start
 
       @tmp_file_path = @tmp_file.path
-
-      begin
-        @process.poll_for_exit(@timeout)
-      rescue ChildProcess::TimeoutError
-        @output << "TIMEOUT"
-        @process.stop # tries increasingly harsher methods to kill the process.
-        return false
-      end
-
-      @process.exit_code == 0
-
     rescue => e
-      # return false if any exception occurs
       @output << e.message
-      false
-
-    ensure
-      @tmp_file.rewind
-      @output << GitlabCi::Encode.encode!(@tmp_file.read)
-      @tmp_file.close
-      @tmp_file.unlink
     end
 
     def checkout_cmd

--- a/lib/network.rb
+++ b/lib/network.rb
@@ -57,15 +57,20 @@ module GitlabCi
 
       response = self.class.put("#{api_url}/builds/#{id}.json", body: options)
 
-      if response.code == 200
+      case response.code
+      when 200
         puts 'ok'
-        true
+        :success
+      when 404
+        puts 'aborted'
+        :aborted
       else
-        puts 'failed'
+        puts "response error: #{response.code}"
+        :failure
       end
-    rescue
-      puts 'failed'
-      false
+    rescue => e
+      puts "failure: #{e.message}"
+      :failure
     end
 
     def register_runner(public_key, token)

--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -8,14 +8,13 @@ module GitlabCi
     def initialize
       puts '* Gitlab CI Runner started'
       puts '* Waiting for builds'
-
       loop do
-        if completed? || running?
+        if running?
+          push_build
           update_build
         else
           get_build
         end
-
         sleep 5
       end
     end
@@ -26,32 +25,26 @@ module GitlabCi
       @current_build
     end
 
-    def completed?
-      @current_build && @current_build.completed?
-    end
-
     def update_build
-      if @current_build.completed?
-        if push_build
-          puts "#{Time.now.to_s} | Completed build #{@current_build.id}"
-          @current_build = nil
-        end
-      else
-        push_build
-      end
+      return unless @current_build.completed?
+      puts "#{Time.now.to_s} | Completed build #{@current_build.id}, #{@current_build.state}."
+      @current_build.cleanup
+      @current_build = nil
     end
 
     def push_build
-      network.update_build(
-        @current_build.id,
-        @current_build.state,
-        @current_build.trace
-      )
+      case network.update_build(@current_build.id, @current_build.state, @current_build.trace)
+      when :success
+        # nothing to do here
+      when :aborted
+        @current_build.abort
+      when :failure
+        # nothing to do here, we simply assume this is a temporary failure communicating with the gitlab-ci server
+      end
     end
 
     def get_build
       build_data = network.get_build
-
       if build_data
         run(build_data)
       else
@@ -65,14 +58,9 @@ module GitlabCi
 
     def run(build_data)
       @current_build = GitlabCi::Build.new(build_data)
-
-      Thread.abort_on_exception = true
-
-      Thread.new(@current_build) do
-        puts "#{Time.now.to_s} | Build #{@current_build.id} started.."
-
-        @current_build.run
-      end
+      puts "#{Time.now.to_s} | Starting new build #{@current_build.id}..."
+      @current_build.run
+      puts "#{Time.now.to_s} | Build #{@current_build.id} started."
     end
 
     def collect_trace


### PR DESCRIPTION
With the current implementation I had several problems:
- aborting running tests from the gitlab-ci didn't work (it marked the job as failed, but didn't kill the build)
- the runner didn't properly handle crashing build scripts (it considered the build is still running forever)

This pull request solves both problems. The way the build commands are executed changed completely. Now the runner creates a single temporary bash script which contains _all_ the commands the build needs. The script itself is then exectued as a child process in its own session (process group) by the runner. This way we can ensure that killing the script also kills all its childs.
