### PR TITLE
Tell users to install bundle locally without sudo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ tmp/*
 .gpairrc
 .ruby-version
 .ruby-gemset
+/.bundle
+/vendor/bundle

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cd gitlab-ci-runner
 Install the gems for the runner:
 
 ```
-bundle install
+bundle install --deployment
 ```
 
 Setup the runner interactively:


### PR DESCRIPTION
On the current README install procedure, the command `bundle install` fails because it tries to install gems to a shared location and that requires sudo.

I think the best thing to do is to do a local install with `--path vendor/bundle`.

Alternatives:
- RVM install for `gitlab_ci_runner` user. Downside: one extra complexity layer by RVM where multiple rubies are probably not needed?
- change back into the main user who has `sudo`, `cd /home/gitlab_ci_runner/gitlab-ci-runner` and `bundle install`.
  
  Explicit `sudo` should not be used as explained by `bundle help install`: it is automatically used where needed.
  
  Downside: may fail because the main user does not have write permission to `Gemfile.lock`.
  
  Works if you are deving with `bindfs` (probably the best option) as suggested at: https://gitlab.com/gitlab-org/cookbook-gitlab/blob/master/doc/development_metal.md
- add the user to the sudo group. Downside: gives more destructive powers to the `gitlab_ci_runner` user.
