### PR TITLE
[ISSUE-37] [ISSUE-82] Encode trace message before update build

### DIFF
--- a/lib/network.rb
+++ b/lib/network.rb
@@ -50,6 +50,8 @@ module GitlabCi
     def update_build(id, state, trace)
       broadcast "Submitting build #{id} to coordinator..."
 
+      trace = trace.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+
       options = default_options.merge(
         state: state,
         trace: trace,


### PR DESCRIPTION
First off I am not a Ruby developer so please bare with me if this might not be the solution to go.
This PR fixes a problem where the build trace being sent to the coordinator during update build breaks the runner resulting in an infinite running build (see issues https://github.com/gitlabhq/gitlab-ci-runner/issues/37 and https://github.com/gitlabhq/gitlab-ci-runner/issues/82.
The problem is if the build trace contains invalid UTF-8 byte sequences, the `PUT` request fails during update build and leaves the runner in an inconsistent state where it cannot break out again.
It's just outputting `Submitting build 379 to coordinator...failed` over and over again.
The result is that the runner has to be killed and restarted.
I adopted a fix suggested [here](http://robots.thoughtbot.com/fight-back-utf-8-invalid-byte-sequences) to come around this issue.
