### PR TITLE
Dockerfile fixed to avoid error on Upstart workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN mkdir /tmp/ruby && cd /tmp/ruby && curl --progress http://ftp.ruby-lang.org/
 RUN cd /tmp/ruby/ruby-1.9.3-p392 && ./configure --disable-install-rdoc && make && make install
 
 # Fix upstart under a virtual host https://github.com/dotcloud/docker/issues/1024
-RUN dpkg-divert --local --rename --add /sbin/initctl
-RUN ln -s /bin/true /sbin/initctl
+RUN dpkg-divert --local --rename --add /sbin/initctl && rm -f /sbin/initctl && ln -s /bin/true /sbin/initctl
 
 # Install packages commonly required to test Rails projects before the test run starts
 # If they are not here you have to add them to the test script in the project settings


### PR DESCRIPTION
Whenever I tried to build the Dockerfile, I was getting an error on the line `RUN ln -s /bin/true /sbin/initctl`, so this should fix it.
