### PR TITLE
Alter way to check for running runners by using PID file

### DIFF
--- a/lib/support/init.d/gitlab_ci_runner
+++ b/lib/support/init.d/gitlab_ci_runner
@@ -24,125 +24,126 @@ RUNNERS_RUNNING=0
 INIT_LOG="/var/log/gitlab_ci_runner.log"
 
 check_pid() {
-    # Number of registered runners in PID file
-    RUNNERS_REGISTERED=0
-    # Number of active runner processes from PID file
-    RUNNERS_RUNNING=0
+  # Number of registered runners in PID file
+  RUNNERS_REGISTERED=0
+  # Number of active runner processes from PID file
+  RUNNERS_RUNNING=0
 
-    if [ -f $RUNNERS_PID ]; then
-        # Registered
-        RUNNERS_REGISTERED=`cat $RUNNERS_PID | wc -l`
+  if [ -f $RUNNERS_PID ]; then
+    # Registered
+    RUNNERS_REGISTERED=`cat $RUNNERS_PID | wc -l`
 
-        # Running
-        while read pid; do
-            if [ -d /proc/$pid ]; then
-                # Process is running
-                ((RUNNERS_RUNNING++))
-            fi
-        done < $RUNNERS_PID
-    fi
+    # Running
+    while read pid; do
+      if [ -d /proc/$pid ]; then
+        # Process is running
+        ((RUNNERS_RUNNING++))
+      fi
+    done < $RUNNERS_PID
+  fi
 
-    echo "Number of registered runners in PID file=$RUNNERS_REGISTERED"
-    echo "Number of running runners=$RUNNERS_RUNNING"
+  echo "Number of registered runners in PID file=$RUNNERS_REGISTERED"
+  echo "Number of running runners=$RUNNERS_RUNNING"
 }
 
 execute() {
-    sudo -u $APP_USER -H bash -l -c "$1"
+  sudo -u $APP_USER -H bash -l -c "$1"
 }
 
 start() {
-    cd $APP_ROOT
-    check_pid
-    if [ "$RUNNERS_REGISTERED" -ne 0 -o "$RUNNERS_RUNNING" -ne 0 ]; then
-        # Program is running, Exit with error code.
-        echo "Error! $DESC(s) ($NAME) appear to be running already! Try stopping them first. Exiting."
-        exit 1
-    else
-        if [ `whoami` = root ]; then
-            [ ! -f $PID_PATH ] && execute "mkdir -p $PID_PATH"
-            [ -f $RUNNERS_PID ] && execute "rm -f $RUNNERS_PID"
+  cd $APP_ROOT
+  check_pid
+  if [ "$RUNNERS_REGISTERED" -ne 0 -o "$RUNNERS_RUNNING" -ne 0 ]; then
+    # Program is running, Exit with error code.
+    echo "Error! $DESC(s) ($NAME) appear to be running already! Try stopping them first. Exiting."
+    exit 1
+  else
+    if [ `whoami` = root ]; then
+      [ ! -f $PID_PATH ] && execute "mkdir -p $PID_PATH"
+      [ -f $RUNNERS_PID ] && execute "rm -f $RUNNERS_PID"
 
-            # Spawn runners
-            for (( i=1; i<=$RUNNERS_NUM; i++ ))
-            do
-                # Check log file
-                if [ ! -f $INIT_LOG ]; then
-                    touch $INIT_LOG
-                    chown $APP_USER $INIT_LOG
-                fi
-                echo "Starting runner #$i"
-                execute "$START_RUNNER  >> $INIT_LOG 2>&1 & echo \$! >> $RUNNERS_PID"
-            done
-            
-            echo "SUCCESS: Started $RUNNERS_NUM $DESC(s)."
+      # Spawn runners
+      for (( i=1; i<=$RUNNERS_NUM; i++ ))
+      do
+        # Check log file
+        if [ ! -f $INIT_LOG ]; then
+          touch $INIT_LOG
+          chown $APP_USER $INIT_LOG
         fi
+       
+        echo "Starting runner #$i"
+        execute "$START_RUNNER  >> $INIT_LOG 2>&1 & echo \$! >> $RUNNERS_PID"
+      done
+      
+      echo "SUCCESS: Started $RUNNERS_NUM $DESC(s)."
     fi
+  fi
 }
 
 stop() {
-    check_pid
-    # Exit if there are no runners
-    if [ $RUNNERS_REGISTERED -eq 0 -a  $RUNNERS_RUNNING -eq 0 ]; then
-        echo "No runners have been found. Exiting."
-    fi
+  check_pid
+  # Exit if there are no runners
+  if [ $RUNNERS_REGISTERED -eq 0 -a  $RUNNERS_RUNNING -eq 0 ]; then
+    echo "No runners have been found. Exiting."
+  fi
 
-    # Runners found. Check if there are any ghost runners.
-    KILL_GHOSTS=0;
-    if [ $RUNNERS_REGISTERED -ne $RUNNERS_RUNNING ]; then
-        echo "WARNING: Numbers of registered runners don't match number of running runners. Will try to stop them all"
-        echo "Registered runners=$RUNNERS_REGISTERED"
-        echo "Running runners=$RUNNERS_RUNNING"
-        KILL_GHOSTS=1;
-    fi
+  # Runners found. Check if there are any ghost runners.
+  KILL_GHOSTS=0;
+  if [ $RUNNERS_REGISTERED -ne $RUNNERS_RUNNING ]; then
+    echo "WARNING: Numbers of registered runners don't match number of running runners. Will try to stop them all"
+    echo "Registered runners=$RUNNERS_REGISTERED"
+    echo "Running runners=$RUNNERS_RUNNING"
+    KILL_GHOSTS=1;
+  fi
 
-    echo -n "Trying to stop registered runners..."
-    if [ $RUNNERS_REGISTERED -gt 0 ]; then
-        execute "cat $RUNNERS_PID | xargs kill -USR2"
-        rm -f $RUNNERS_PID
-        echo "OK"
-    else
-        echo "FAILED!"
-        echo "Couldn't stop registered runners as there is no record of such in $RUNNERS_PID file".
-    fi
+  echo -n "Trying to stop registered runners..."
+  if [ $RUNNERS_REGISTERED -gt 0 ]; then
+    execute "cat $RUNNERS_PID | xargs kill -USR2"
+    rm -f $RUNNERS_PID
+    echo "OK"
+  else
+    echo "FAILED!"
+    echo "Couldn't stop registered runners as there is no record of such in $RUNNERS_PID file".
+  fi
 
-    if [ $KILL_GHOSTS -eq 1 ]; then
-        echo -ne "Trying to kill ghost runners..."
-        ps -C "$PROCESS_NAME" -o "%p" h | xargs kill -USR2
-        [ $? -eq 0 ] && echo "OK"
-    else
-        echo "No ghost runners have been found.This is good."
-    fi
+  if [ $KILL_GHOSTS -eq 1 ]; then
+    echo -ne "Trying to kill ghost runners..."
+    ps -C "$PROCESS_NAME" -o "%p" h | xargs kill -USR2
+    [ $? -eq 0 ] && echo "OK"
+  else
+    echo "No ghost runners have been found.This is good."
+  fi
 }
 
 status() {
-    echo "Here is what we have at the moment:"
-    check_pid
+  echo "Here is what we have at the moment:"
+  check_pid
 }
 
 ## Check to see if we are running as root first.
 if [ "$(id -u)" != "0" ]; then
-    echo "This script must be run as root"
-    exit 1
+  echo "This script must be run as root"
+  exit 1
 fi
 
 case "$1" in
-    start)
-        start
-        ;;
-    stop)
-        stop
-        ;;
-    restart)
-        stop
-        start
-        ;;
-    status)
-        status
-        ;;
-    *)
-        echo "Usage: sudo service gitlab_ci_runner {start|stop|restart|status}" >&2
-        exit 1
-        ;;
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart)
+    stop
+    start
+    ;;
+  status)
+    status
+    ;;
+  *)
+    echo "Usage: sudo service gitlab_ci_runner {start|stop|restart|status}" >&2
+    exit 1
+    ;;
 esac
 
 exit 0


### PR DESCRIPTION
The check_pid function has been changed to go over the pids in the pid file and see if there are running processes with those ids. This also makes pull request #66 superflous.

All other changes are purely whitespace (tabs to 4 spaces). It was a mess all over so I just cleaned that up.
