### PR TITLE
Default file for gitlab ci runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,15 @@ exit;
 cd /home/gitlab_ci_runner/gitlab-ci-runner
 sudo cp ./lib/support/init.d/gitlab_ci_runner /etc/init.d/gitlab-ci-runner
 sudo chmod +x /etc/init.d/gitlab-ci-runner
-sudo update-rc.d gitlab-ci-runner defaults 21 
+sudo update-rc.d gitlab-ci-runner defaults 21
 ```
 
+### Runners default file
+
+```
+cd /home/gitlab_ci_runner/gitlab-ci-runner
+sudo cp ./lib/support/init.d/gitlab_ci_runner.default.example /etc/default/gitlab_ci_runner
+```
 
 ### Run
 
@@ -154,7 +160,7 @@ bundle exec bin/runner -C /my/runner/working/directory
 
 ### Update
 
-In order to update the runner to a new version just go to runner directory and do next: 
+In order to update the runner to a new version just go to runner directory and do next:
 
 ```bash
 sudo su gitlab_ci_runner
@@ -181,4 +187,3 @@ Now the runner will start to pick up builds automatically. When you are done wit
 ## Development
 
 To work on the GitLab runner we recommend you install the [GitLab Development Kit](https://gitlab.com/gitlab-org/gitlab-development-kit).
-

--- a/lib/support/init.d/gitlab_ci_runner
+++ b/lib/support/init.d/gitlab_ci_runner
@@ -7,7 +7,7 @@
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: GitLab CI Runner init.d script
-# Description:       Enables automatic start of runners at boot time in the background.
+# Description: Enables automatic start of runners at boot time in the background.
 ### END INIT INFO
 
 APP_ROOT="/home/gitlab_ci_runner/gitlab-ci-runner"
@@ -20,6 +20,9 @@ NAME="gitlab-ci-runner"
 DESC="GitLab CI runner"
 RUNNERS_REGISTERED=0
 INIT_LOG="/var/log/gitlab_ci_runner.log"
+
+# Read configuration variable file if it is present
+test -f /etc/default/gitlab_ci_runner && . /etc/default/gitlab_ci_runner
 
 check_pid() {
   PROCESS_ID=0
@@ -45,7 +48,6 @@ start() {
       [ ! -f $PID_PATH ] && execute "mkdir -p $PID_PATH"
       [ -f $RUNNER_PID ] && execute "rm -f $RUNNER_PID"
 
-      
       # Check log file
       if [ ! -f $INIT_LOG ]; then
         touch $INIT_LOG
@@ -60,7 +62,7 @@ start() {
 stop() {
  check_pid
  echo -n "Trying to stop registered runner..."
- 
+
  if [ $PROCESS_ID -gt 0 ]; then
    execute "cat $RUNNER_PID | xargs kill -USR2"
    rm -f $RUNNER_PID
@@ -84,22 +86,22 @@ fi
 
 case "$1" in
   start)
-        start
-        ;;
+    start
+    ;;
  stop)
-        stop
-        ;;
+    stop
+    ;;
   restart)
-        stop
-        start
-        ;;
+    stop
+    start
+    ;;
   status)
-        status
-        ;;
+    status
+    ;;
   *)
-        echo "Usage: sudo service gitlab_ci_runner {start|stop|restart|status}" >&2
-        exit 1
-        ;;
+    echo "Usage: sudo service gitlab_ci_runner {start|stop|restart|status}" >&2
+    exit 1
+    ;;
 esac
 
 exit 0

--- a/lib/support/init.d/gitlab_ci_runner.default.example
+++ b/lib/support/init.d/gitlab_ci_runner.default.example
@@ -1,0 +1,25 @@
+# Copy this lib/support/init.d/gitlab_ci_runner.default.example file to
+# /etc/default/gitlab_ci_runner in order for it to apply to your system.
+
+# app_user defines the user that GitLab is run as.
+# The default is "gitlab_ci_runner".
+APP_USER="gitlab_ci_runner"
+
+# app_root defines the folder in which gitlab and it's components are installed.
+# The default is "/home/$app_user/gitlab-ci-runner"
+APP_ROOT="/home/$APP_USER/gitlab-ci-runner"
+
+# pid_path defines a folder in which the gitlab-ci-runner place its pid.
+# This variable is also used below to define the relevant pids for the gitlab_ci_runner components.
+# The default is "$app_root/tmp/pids"
+PID_PATH="$APP_ROOT/tmp/pids"
+
+# init_log defines a file in which the runners write their log messages.
+# The default is "/var/log/gitlab_ci_runner.log"
+INIT_LOG="/var/log/gitlab_ci_runner.log"
+
+# Runner Configuration
+
+# runners_pid_path defines a file in which the individual runners place their pids.
+# The default is "$pid_path/runners.pid"
+RUNNERS_PID="$PID_PATH/runners.pid"


### PR DESCRIPTION
@jvanbaarsen New try of #98

What did I change:

* Added default file for init script to allow configuration for the
runner
* Updated install area inside ReadMe.md
* Adapted the indention of the switch-case to match the rest of the
script

**EDIT:**

* Fixed description of line 17
* Edited init.d-script variables to lowercase variables to match
default file