### PR TITLE
fix gitlab-ci-runner init.d script for debian

### DIFF
--- a/lib/support/init.d/gitlab_ci_runner
+++ b/lib/support/init.d/gitlab_ci_runner
@@ -36,7 +36,7 @@ check_pid() {
 }
 
 execute() {
-  sudo -u $APP_USER -H bash -l -c "$1"
+  su $APP_USER -s /bin/bash -c "$1"
  }
 
 start() {


### PR DESCRIPTION
This commit addresses an issue with the gitlab-ci-runner init.d script on Debian based systems.
This script makes use of `sudo` which raise two problems on Debian:

1. by default `sudo` is not installed on Debian,
2. even if `sudo` is installed, `root` is not a sudoer by default on Debian

As a result the `execute` function from gitlab-ci-runner fails.

This commit replaces the following `execute` function from:

    sudo -u $APP_USER -H bash -l -c "$1"

To

    su $APP_USER -s /bin/bash -c "$1"

Signed-off-by: Remi BARRAQUAND <dev@remibarraquand.com>
Signed-off-by: Charles EYNARD <charles.eynard@yeastlab.fr>