### PR TITLE
Don't try running "kill" on empty process list

### DIFF
--- a/lib/support/init.d/gitlab_ci_runner
+++ b/lib/support/init.d/gitlab_ci_runner
@@ -96,10 +96,10 @@ stop() {
 
  if [ $KILL_GHOSTS -eq 1 ]; then
    echo -ne "Trying to kill ghost runners..."
-   ps -C "$PROCESS_NAME" -o "%p" h | xargs kill -USR2
+   ps -C "$PROCESS_NAME" -o "%p" h | xargs -r kill -USR2
    [ $? -eq 0 ] && echo "OK"
  else
-   echo "No ghost runners have been found.This is good."
+   echo "No ghost runners have been found. This is good."
  fi
 }
 


### PR DESCRIPTION
I'm running Gitlab CI runner on  Ubuntu 14.04.1 LTS which is listed as a supported distro. When using init script provided, I once in a while get:

```
root@ubuntu# service gitlab-ci-runner restart
Number of registered runners in PID file=1
Number of running runners=0
WARNING: Numbers of registered runners don't match number of running runners. Will try to stop them all
Registered runners=1
Running runners=0
Trying to stop registered runners...OK
Trying to kill ghost runners...kill: invalid argument U

Usage:
 kill [options] <pid> [...]

Options:
 <pid> [...]            send signal to every <pid> listed
 -<signal>, -s, --signal <signal>
                        specify the <signal> to be sent
 -l, --list=[<signal>]  list all signal names, or convert one to a name
 -L, --table            list all signal names in a nice table

 -h, --help     display this help and exit
 -V, --version  output version information and exit

For more details see kill(1).
Number of registered runners in PID file=1
Number of running runners=0
Error! GitLab CI runner(s) (gitlab-ci-runner) appear to be running already! Try stopping them first. Exiting.
```

This is because the output of ```ps -C "$PROCESS_NAME" -o "%p" h``` was empty but ```xargs``` was trying to send ```USR2``` signal anyway, which resulted in wrong syntax and aforementioned error message. ```-r``` flag tells ```xargs``` not to run the command if output of previous command is empty, which fixed this issue for me.

Also, there was a typo.