### PR TITLE
Remove git clean -fdx command

### DIFF
--- a/lib/build.rb
+++ b/lib/build.rb
@@ -171,7 +171,6 @@ module GitlabCi
       cmd = []
       cmd << "cd #{project_dir}"
       cmd << "git reset --hard"
-      cmd << "git clean -fdx"
       cmd << "git remote set-url origin #{@repo_url}"
       cmd << "git fetch origin"
       cmd.join(" && ")


### PR DESCRIPTION
This command removes the local files installed by bundle install.  Doing this before every build causes bundle install to install the entire bundle before every build.  Let's let the user decide whether or not to clean in their build script, vs. forcing this step.