### PR TITLE
Deleted port 3000 in example

### DIFF
--- a/lib/setup.rb
+++ b/lib/setup.rb
@@ -14,7 +14,7 @@ module GitlabCi
     def build_config
       url = ENV['CI_SERVER_URL']
       unless url
-        puts 'Please enter the gitlab-ci coordinator URL (e.g. http://gitlab-ci.org:3000/ )'
+        puts 'Please enter the gitlab-ci coordinator URL (e.g. http://gitlab-ci.org/ )'
         url = gets.chomp
       end
 


### PR DESCRIPTION
Port was deleted since 3000 seems to be no more the default port (maybe old documentation?).