### PR TITLE
mac os fix Error: Cowardly refusing to

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ sudo apt-get install -y wget curl gcc libxml2-dev libxslt-dev libcurl4-openssl-d
 b) MacOSX (make sure you have [homebrew](http://brew.sh/) installed)
 
 ```bash
-sudo brew install icu4c
+brew install icu4c
 ```
 
 Install Ruby from source:


### PR DESCRIPTION
Error: Cowardly refusing to `sudo brew install`
You can use brew with sudo, but only if the brew executable is owned by root.
However, this is both not recommended and completely unsupported so do so at
your own risk.