### PR TITLE
Changed Ruby install instructions to version 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ a) Linux
 
 ```bash
 mkdir /tmp/ruby && cd /tmp/ruby
-curl --progress ftp://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.gz | tar xz
-cd ruby-2.0.0-p353
+curl --progress ftp://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz | tar xz
+cd ruby-2.1.2
 ./configure --disable-install-rdoc
 make
 sudo make install


### PR DESCRIPTION
Ruby 2.0.0-p353 does not compile on Ubuntu 14.04. Replaced it with 2.1.2 (copied from the GitLab upgrade guide)