### PR TITLE
Add pre/post_build_cmd config item, a system command to be run before/after each build

### DIFF
--- a/lib/build.rb
+++ b/lib/build.rb
@@ -25,12 +25,14 @@ module GitlabCi
       @before_sha = data[:before_sha]
       @timeout = data[:timeout] || TIMEOUT
       @allow_git_fetch = data[:allow_git_fetch]
+      @pre_build_cmd = config.pre_build_cmd
     end
 
     def run
       @run_file = Tempfile.new("executor")
       @run_file.chmod(0700)
 
+      @commands.unshift(pre_build_cmd)
       @commands.unshift(checkout_cmd)
 
       if repo_exists? && @allow_git_fetch

--- a/lib/build.rb
+++ b/lib/build.rb
@@ -28,8 +28,9 @@ module GitlabCi
     end
 
     def run
-      puts "Executing pre_build_cmd: #{config.pre_build_cmd}"
-      system(config.pre_build_cmd) 
+      if config.pre_build_cmd
+        puts "Executing pre_build_cmd: #{config.pre_build_cmd}"
+        system(config.pre_build_cmd) 
 
       @run_file = Tempfile.new("executor")
       @run_file.chmod(0700)

--- a/lib/build.rb
+++ b/lib/build.rb
@@ -25,14 +25,15 @@ module GitlabCi
       @before_sha = data[:before_sha]
       @timeout = data[:timeout] || TIMEOUT
       @allow_git_fetch = data[:allow_git_fetch]
-      @pre_build_cmd = config.pre_build_cmd
     end
 
     def run
+      puts "Executing pre_build_cmd: #{config.pre_build_cmd}"
+      system(config.pre_build_cmd) 
+
       @run_file = Tempfile.new("executor")
       @run_file.chmod(0700)
 
-      @commands.unshift(pre_build_cmd)
       @commands.unshift(checkout_cmd)
 
       if repo_exists? && @allow_git_fetch

--- a/lib/build.rb
+++ b/lib/build.rb
@@ -31,6 +31,7 @@ module GitlabCi
       if config.pre_build_cmd
         puts "Executing pre_build_cmd: #{config.pre_build_cmd}"
         system(config.pre_build_cmd) 
+      end
 
       @run_file = Tempfile.new("executor")
       @run_file.chmod(0700)

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -14,6 +14,10 @@ module GitlabCi
       end
     end
 
+    def post_build_cmd
+      @config['post_build_cmd']
+    end
+
     def token
       @config['token']
     end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -18,6 +18,10 @@ module GitlabCi
       @config['post_build_cmd']
     end
 
+    def pre_build_cmd
+      @config['pre_build_cmd']
+    end
+
     def token
       @config['token']
     end

--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -43,8 +43,8 @@ module GitlabCi
         @current_build.cleanup
         @current_build = nil
         if config.post_build_cmd
-            puts "Running post_build_cmd: #{config.post_build_cmd}"
-            system(config.post_build_cmd)
+          puts "Running post_build_cmd: #{config.post_build_cmd}"
+          system(config.post_build_cmd)
         end
       else
         # wait when ci server will be online again to submit build results
@@ -90,7 +90,7 @@ module GitlabCi
     end
 
     def config
-        @config ||= Config.new
+      @config ||= Config.new
     end
   end
 end

--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -1,5 +1,6 @@
 require_relative 'build'
 require_relative 'network'
+require_relative 'config'
 
 module GitlabCi
   class Runner
@@ -41,6 +42,10 @@ module GitlabCi
       if push_build
         @current_build.cleanup
         @current_build = nil
+        if config.post_build_cmd
+            puts "Running post_build_cmd: #{config.post_build_cmd}"
+            system(config.post_build_cmd)
+        end
       else
         # wait when ci server will be online again to submit build results
       end
@@ -82,6 +87,10 @@ module GitlabCi
 
     def collect_trace
       @current_build.trace
+    end
+
+    def config
+        @config ||= Config.new
     end
   end
 end


### PR DESCRIPTION
I use this to have the runner (which is in a read-only live-cd-style VM image) reboot after each build, so it's pristine again when it starts a new job.
