### PR TITLE
Fix issue where runners would not start after server hard-reset

### DIFF
--- a/lib/support/init.d/gitlab_ci_runner
+++ b/lib/support/init.d/gitlab_ci_runner
@@ -42,7 +42,7 @@ execute() {
 start() {
   cd $APP_ROOT
   check_pid
-  if [ "$RUNNERS_REGISTERED" -ne 0 -o "$RUNNERS_RUNNING" -ne 0 ]; then
+  if [ "$RUNNERS_REGISTERED" -ne 0 -a "$RUNNERS_RUNNING" -ne 0 ]; then
     # Program is running, Exit with error code.
     echo "Error! $DESC(s) ($NAME) appear to be running already! Try stopping them first. Exiting."
     exit 1


### PR DESCRIPTION
This change is to fix issue which prevents gitlab-ci-runners from starting if server was reset ( without graceful shutdown ) or if runner process was killed without removing pid file.