### PR TITLE
fix hardcoded path to /bin/bash

### DIFF
--- a/lib/build.rb
+++ b/lib/build.rb
@@ -41,7 +41,7 @@ module GitlabCi
         @commands.unshift(clone_cmd)
       end
 
-      @run_file.puts %|#!/bin/bash|
+      @run_file.puts %|#!/usr/bin/env bash|
       @run_file.puts %|set -e|
       @run_file.puts %|trap 'kill -s INT 0' EXIT|
 


### PR DESCRIPTION
see #125
Using '/usr/bin/env bash' adds more portability.

Sorry for creating a separate issue for this before creating a pull request, but I didn't realize that the solution would be so simple.
