### PR TITLE
run bash with x flag instead of echo.

### DIFF
--- a/lib/build.rb
+++ b/lib/build.rb
@@ -42,12 +42,11 @@ module GitlabCi
       end
 
       @run_file.puts %|#!/bin/bash|
-      @run_file.puts %|set -e|
       @run_file.puts %|trap 'kill -s INT 0' EXIT|
+      @run_file.puts %|set -ex|
 
       @commands.each do |command|
         command.strip!
-        @run_file.puts %|echo #{command.shellescape}|
         @run_file.puts(command)
       end
       @run_file.close


### PR DESCRIPTION
the echo mode break multiline statements in the job file makeing it very
hard to do something readable or echo a multiline statement into a file.

bash already provides this functionality with the x flag, so simply activate it.