### PR TITLE
Force git clean to remove all directories

### DIFF
--- a/lib/build.rb
+++ b/lib/build.rb
@@ -175,7 +175,7 @@ module GitlabCi
       cmd = []
       cmd << "cd #{project_dir}"
       cmd << "git reset --hard"
-      cmd << "git clean -fdx"
+      cmd << "git clean -ffdx"
       cmd << "git remote set-url origin #{@repo_url}"
       cmd << "git fetch origin"
       cmd.join(" && ")


### PR DESCRIPTION
By default git clean won't remove git subdirs.

This patch ensures that all git subdirs will be removed before starting the test.
